### PR TITLE
Implemented new type Decimals, fixed comments, setter for comparison precision

### DIFF
--- a/decimal/decimal.go
+++ b/decimal/decimal.go
@@ -54,8 +54,8 @@ var oneInt = big.NewInt(1)
 var fiveInt = big.NewInt(5)
 var tenInt = big.NewInt(10)
 
-// constant for ~ comparison
-var val10em2 = NewFromFloat(0.00999999999)
+// comparePrecision is a constant for ~ comparison
+var comparePrecision = NewFromFloat(0.00999999999)
 
 // Decimal represents a fixed-point decimal. It is immutable.
 // number = value * 10 ^ exp
@@ -661,7 +661,7 @@ func unquoteIfQuoted(value interface{}) (string, error) {
 	Возвращает true если d > d2 более чем на 10e-2
 */
 func (d Decimal) Gt(d2 Decimal) bool {
-	if d.Sub(d2).Cmp(val10em2) == 1 {
+	if d.Sub(d2).Cmp(comparePrecision) == 1 {
 		return true
 	}
 	return false
@@ -678,7 +678,7 @@ func (d Decimal) Ge(d2 Decimal) bool {
 	Возвращает true если d < d2 более чем на 10e-2
 */
 func (d Decimal) Lt(d2 Decimal) bool {
-	if d2.Sub(d).Cmp(val10em2) == 1 {
+	if d2.Sub(d).Cmp(comparePrecision) == 1 {
 		return true
 	}
 	return false
@@ -688,7 +688,7 @@ func (d Decimal) Lt(d2 Decimal) bool {
 	Возвращает true если d ~ d2 в порядке 10e-2
 */
 func (d Decimal) Eq(d2 Decimal) bool {
-	if d.Sub(d2).Abs().Cmp(val10em2) == -1 {
+	if d.Sub(d2).Abs().Cmp(comparePrecision) == -1 {
 		return true
 	}
 	return false
@@ -713,4 +713,9 @@ func (d Decimal) Le(d2 Decimal) bool {
 */
 func (d Decimal) Neg() Decimal {
 	return Zero.Sub(d)
+}
+
+// Copy copies d and returns the copy
+func (d Decimal) Copy() Decimal {
+	return d.Add(Zero)
 }

--- a/decimal/decimal.go
+++ b/decimal/decimal.go
@@ -54,8 +54,13 @@ var oneInt = big.NewInt(1)
 var fiveInt = big.NewInt(5)
 var tenInt = big.NewInt(10)
 
-// comparePrecision is a constant for ~ comparison
+// comparePrecision is a constant for ~ comparison, it have the following default value
 var comparePrecision = NewFromFloat(0.00999999999)
+
+// SetComparePrecision sets the compare precision
+func SetComparePrecision(precision float64) {
+	comparePrecision = NewFromFloat(precision)
+}
 
 // Decimal represents a fixed-point decimal. It is immutable.
 // number = value * 10 ^ exp
@@ -657,60 +662,37 @@ func unquoteIfQuoted(value interface{}) (string, error) {
 	return string(bytes), nil
 }
 
-/*
-	Возвращает true если d > d2 более чем на 10e-2
-*/
+// Gt returns true id d > d2 with precision comparePrecision
 func (d Decimal) Gt(d2 Decimal) bool {
-	if d.Sub(d2).Cmp(comparePrecision) == 1 {
-		return true
-	}
-	return false
+	return d.Sub(d2).Cmp(comparePrecision) == 1
 }
 
-/*
-	Возвращает true если d >= d2 более чем на 10e-2
-*/
+// Ge returns true id d >= d2 with precision comparePrecision
 func (d Decimal) Ge(d2 Decimal) bool {
 	return d.Gt(d2) || d.Eq(d2)
 }
 
-/*
-	Возвращает true если d < d2 более чем на 10e-2
-*/
+// Lt returns true id d < d2 with precision comparePrecision
 func (d Decimal) Lt(d2 Decimal) bool {
-	if d2.Sub(d).Cmp(comparePrecision) == 1 {
-		return true
-	}
-	return false
+	return d2.Sub(d).Cmp(comparePrecision) == 1
 }
 
-/*
-	Возвращает true если d ~ d2 в порядке 10e-2
-*/
+// Eq returns true id d == d2 with precision comparePrecision
 func (d Decimal) Eq(d2 Decimal) bool {
-	if d.Sub(d2).Abs().Cmp(comparePrecision) == -1 {
-		return true
-	}
-	return false
+	return d.Sub(d2).Abs().Cmp(comparePrecision) == -1
 }
 
-/*
-	Возвращает true если d !~ d2 в порядке 10e-2
-*/
+// Ne returns true id d != d2 with precision comparePrecision
 func (d Decimal) Ne(d2 Decimal) bool {
 	return !d.Eq(d2)
 }
 
-/*
-	Возвращает true если d <= d2 более чем на 10e-2
-*/
+// Le returns true id d <= d2 with precision comparePrecision
 func (d Decimal) Le(d2 Decimal) bool {
 	return d.Lt(d2) || d.Eq(d2)
 }
 
-/*
-	Возвращает -d
-*/
+// Neg returns -d
 func (d Decimal) Neg() Decimal {
 	return Zero.Sub(d)
 }

--- a/decimal/decimals.go
+++ b/decimal/decimals.go
@@ -1,0 +1,70 @@
+package decimal
+
+import (
+	"sort"
+)
+
+type Decimals []Decimal
+
+func (decimals Decimals) Len() int           { return len(decimals) }
+func (decimals Decimals) Less(i, j int) bool { return decimals[i].Cmp(decimals[j]) < 0 }
+func (decimals Decimals) Swap(i, j int)      { decimals[i], decimals[j] = decimals[j], decimals[i] }
+func (decimals Decimals) Sort()              { sort.Sort(decimals) }
+
+// Copy copies a slice of decimals
+func (decimals Decimals) Copy() Decimals {
+	result := make(Decimals, len(decimals))
+	for i, d := range decimals {
+		result[i] = d.Copy()
+	}
+	return result
+}
+
+// Equal compares two slices, decimals and decimals2, of Decimal
+// if ordered is true, comparing order also, otherwise order may differ
+// if precise is true, compare according comparePrecision
+// if slices are equal according to parameter conditions, it returns true, otherwise returns false
+func (decimals Decimals) Equal(decimals2 Decimals, ordered bool, precise bool) bool {
+	if len(decimals) != len(decimals2) {
+		return false
+	}
+
+	copy1, copy2 := decimals.Copy(), decimals2.Copy()
+	if !ordered {
+		copy1.Sort()
+		copy2.Sort()
+	}
+
+	for i, _ := range copy1 {
+		if precise {
+			if copy1[i].Cmp(copy2[i]) != 0 {
+				return false
+			}
+		} else {
+			if copy1[i].Ne(copy2[i]) {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+// RemoveDuplicates returns a slice decimals which don't contain duplicate elements from decimals slice
+func (decimals Decimals) RemoveDuplicates() Decimals {
+	copy := decimals.Copy()
+	result := Decimals{}
+	for i := 0; i < len(copy); i++ {
+		exists := false
+		for j := 0; j < i; j++ {
+			if copy[j].Eq(copy[i]) {
+				exists = true
+				break
+			}
+		}
+		if !exists { // append this one if no previous same element exists
+			result = append(result, copy[i])
+		}
+	}
+	return result
+}

--- a/decimal/decimals_test.go
+++ b/decimal/decimals_test.go
@@ -1,0 +1,66 @@
+package decimal
+
+import (
+	"testing"
+)
+
+// TestSort checks sorting of Decimals
+func TestSort(t *testing.T) {
+	testCase := Decimals{F(-1.25), Zero, F(1.25), F(-1.26), F(-1.259), F(1), F(-1.261), F(1.249), F(1.251), F(1)}
+	testCase.Sort()
+	expectedResult := Decimals{F(-1.261), F(-1.26), F(-1.259), F(-1.25), Zero, F(1), F(1), F(1.249), F(1.25), F(1.251)}
+	if !testCase.Equal(expectedResult, true, false) {
+		t.Fatalf("Sorting don't work as expected: %v", testCase)
+	}
+}
+
+// TestEqual checks two Decimals equality
+func TestEqual(t *testing.T) {
+	oldComparePrecision := comparePrecision.Float64f()
+	defer SetComparePrecision(oldComparePrecision)
+	SetComparePrecision(0.00999999999)
+
+	type testCase struct {
+		input1         Decimals
+		input2         Decimals
+		ordered        bool
+		precise        bool
+		expectedResult bool
+	}
+
+	testCases := []testCase{
+		testCase{Decimals{F(-1.25), Zero, F(1.25)}, Decimals{F(-1.25), Zero, F(1.25)}, true, true, true},
+		testCase{Decimals{F(-1.25), Zero, F(1.25)}, Decimals{F(-1.25), Zero, F(1.251)}, true, false, true},
+		testCase{Decimals{F(-1.251), Zero, F(1.25)}, Decimals{F(-1.25), Zero, F(1.25)}, true, false, true},
+		testCase{Decimals{F(-1.249), Zero, F(1.25)}, Decimals{F(-1.25), Zero, F(1.25)}, true, false, true},
+		testCase{Decimals{F(-1.25), Zero, F(1.25)}, Decimals{F(-1.25), Zero, F(1.251)}, true, true, false},
+		testCase{Decimals{F(-1.251), Zero, F(1.25)}, Decimals{F(-1.25), Zero, F(1.25)}, true, true, false},
+		testCase{Decimals{F(-1.249), Zero, F(1.25)}, Decimals{F(-1.25), Zero, F(1.25)}, true, true, false},
+		testCase{Decimals{F(-1.25), Zero, F(1.25)}, Decimals{F(-1.25), F(1.25), Zero}, true, true, false},
+		testCase{Decimals{F(-1.25), Zero, F(1.25)}, Decimals{F(-1.25), F(1.25), Zero}, false, true, true},
+		testCase{Decimals{F(-1.25), Zero, F(1.25)}, Decimals{F(-1.25), F(1.25), Zero, Zero}, false, false, false},
+	}
+
+	for i, tc := range testCases {
+		result := tc.input1.Equal(tc.input2, tc.ordered, tc.precise)
+		if result != tc.expectedResult {
+			t.Fatalf("Failed at index %d, ordered=%v, precise=%v, result: %v, expected: %v",
+				i, tc.ordered, tc.precise, result, tc.expectedResult)
+		}
+	}
+}
+
+// TestRemoveDuplicates checks removing duplicates from Decimals
+func TestRemoveDuplicates(t *testing.T) {
+	oldComparePrecision := comparePrecision.Float64f()
+	defer SetComparePrecision(oldComparePrecision)
+	SetComparePrecision(0.00999999999)
+
+	testCase := Decimals{F(-1.25), Zero, F(1.25), F(-1.26), F(-1.259), F(1), F(-1.261), F(1.249), F(1.251), F(1),
+		F(-1.26), F(-1.261), F(-1.259)}
+	expectedResult := Decimals{F(-1.25), Zero, F(1.25), F(-1.26), F(1)}
+	result := testCase.RemoveDuplicates()
+	if !result.Equal(expectedResult, false, true) {
+		t.Fatalf("RemoveDuplicates don't work as expected: %v", result)
+	}
+}


### PR DESCRIPTION
Hi, I implemented several improvements to Decimal. 

**It is 100% compatible with latest in your repo.** 

- Added new type Decimals as slice of Decimal
- Decimals.Equal() to compare two slices of Decimal with settings (ordered, precise)
- Decimals.Sort() to sort slice of Decimal
- Decimal.RemoveDuplicates() to remove unprecise duplicates (like in Gt() etc) from slice of Decimal
- Decimals.Copy(). Decimal.Copy() to copy the value, we can't simply `=` it due to pointer inside a struct, and that fiels is unexportable
- Added SetComparePrecision() to change the precision used in Decimal Gt(), Ge(), Eq(), Ne(), Lt(), Le() and Decimals Equal(), RemoveDuplicates() methods
- Refactored compare methods
- Fixed comments